### PR TITLE
Fix kdialog space encoding

### DIFF
--- a/src/dialog_impl/gnu/message.rs
+++ b/src/dialog_impl/gnu/message.rs
@@ -59,7 +59,7 @@ fn convert_qt_text_document(text: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\n', "<br>")
-        .replace(' ', "&nbsp")
+        .replace(' ', "&nbsp;")
         .replace('\t', "&nbsp;")
 }
 


### PR DESCRIPTION
The space character was being replaced by `&nbsp` which is missing a semicolon at the end to be a valid encoding