### PR TITLE
Dialog box text is now formatted correctly

### DIFF
--- a/src/dialog_impl/gnu/message.rs
+++ b/src/dialog_impl/gnu/message.rs
@@ -77,7 +77,7 @@ fn call_kdialog(mut command: Command, params: Params) -> Result<bool> {
         command.arg("--msgbox");
     }
 
-    command.arg(convert_qt_text_document(params.text));
+    command.arg(params.text);
 
     command.arg("--title");
     command.arg(params.title);


### PR DESCRIPTION
This PR fixes an issue with KDialog where the text would appear badly formatted.

![Screenshot_20230507_115628](https://user-images.githubusercontent.com/22224438/236697225-5560742e-a917-4aad-a9ab-85cf09e6bb75.png)

Closes #41 