### PR TITLE
Version checking for kdialog formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/balthild/native-dialog-rs"
 thiserror = "1.0.19"
 dirs-next = "2.0.0"
 raw-window-handle = "0.4.2"
+ascii = "1.1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 wfd = "0.1.7"
@@ -31,13 +32,7 @@ once_cell = "1.4.0"
 
 [features]
 windows_dpi_awareness = []
-windows_visual_styles = [
-    "once_cell",
-    "winapi/sysinfoapi",
-    "winapi/winbase",
-    "winapi/handleapi",
-    "winapi/libloaderapi",
-]
+windows_visual_styles = ["once_cell", "winapi/sysinfoapi", "winapi/winbase", "winapi/handleapi", "winapi/libloaderapi"]
 
 [workspace]
 members = [

--- a/src/dialog_impl/gnu/message.rs
+++ b/src/dialog_impl/gnu/message.rs
@@ -52,17 +52,6 @@ fn escape_pango_entities(text: &str) -> String {
         .replace('\'', "&apos;")
 }
 
-/// See https://github.com/qt/qtbase/blob/2e2f1e2/src/gui/text/qtextdocument.cpp#L166
-fn convert_qt_text_document(text: &str) -> String {
-    text.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\n', "<br>")
-        .replace(' ', "&nbsp")
-        .replace('\t', "&nbsp;")
-}
-
 struct Params<'a> {
     title: &'a str,
     text: &'a str,
@@ -77,7 +66,7 @@ fn call_kdialog(mut command: Command, params: Params) -> Result<bool> {
         command.arg("--msgbox");
     }
 
-    command.arg(convert_qt_text_document(params.text));
+    command.arg(params.text);
 
     command.arg("--title");
     command.arg(params.title);

--- a/src/dialog_impl/gnu/message.rs
+++ b/src/dialog_impl/gnu/message.rs
@@ -111,7 +111,7 @@ fn call_kdialog(mut command: Command, params: Params) -> Result<bool> {
         command.arg("--msgbox");
     }
 
-    command.arg(params.text);
+    command.arg(convert_qt_text_document(params.text));
 
     command.arg("--title");
     command.arg(params.title);

--- a/src/dialog_impl/gnu/message.rs
+++ b/src/dialog_impl/gnu/message.rs
@@ -1,3 +1,5 @@
+use ascii::AsAsciiStr;
+
 use super::{should_use, UseCommand};
 use crate::dialog::{DialogImpl, MessageAlert, MessageConfirm};
 use crate::{Error, MessageType, Result};
@@ -50,6 +52,49 @@ fn escape_pango_entities(text: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&apos;")
+}
+
+/// See https://github.com/qt/qtbase/blob/2e2f1e2/src/gui/text/qtextdocument.cpp#L166
+fn convert_qt_text_document(text: &str) -> String {
+    if let Some(version) = get_kdialog_version() {
+        if version.0 <= 19 {
+            return text
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;")
+                .replace('"', "&quot;")
+                .replace('\n', "<br>")
+                .replace(' ', "&nbsp")
+                .replace('\t', "&nbsp;");
+        }
+    }
+
+    text
+        .replace('\n', "<br>")
+        .replace('\t', " ")
+}
+
+pub(crate) fn get_kdialog_version() -> Option<(i32, i32, i32)> {
+    let mut command = Command::new("kdialog");
+    command.arg("--version");
+
+    let output = command.output().ok()?;
+    let stdout = output.stdout.as_ascii_str().ok()?;
+    let ver_str = stdout.to_string();
+
+    let mut split = ver_str.split(".");
+
+    let major_with_name = split.next()?;
+    let major_ver_str = major_with_name.split(" ").last()?;
+    let major_ver = major_ver_str.parse::<i32>().ok()?;
+
+    let minor_ver_str = split.next()?;
+    let minor_ver = minor_ver_str.parse::<i32>().ok()?;
+
+    let patch_str_ascii = split.next()?;
+    let patch_ver = patch_str_ascii.replace('\n', "").parse::<i32>().ok()?;
+
+    Some((major_ver, minor_ver, patch_ver))
 }
 
 struct Params<'a> {

--- a/src/dialog_impl/gnu/message.rs
+++ b/src/dialog_impl/gnu/message.rs
@@ -69,9 +69,7 @@ fn convert_qt_text_document(text: &str) -> String {
         }
     }
 
-    text
-        .replace('\n', "<br>")
-        .replace('\t', " ")
+    text.replace('\n', "<br>").replace('\t', " ")
 }
 
 pub(crate) fn get_kdialog_version() -> Option<(i32, i32, i32)> {

--- a/src/dialog_impl/gnu/mod.rs
+++ b/src/dialog_impl/gnu/mod.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::process::Command;
 
 mod file;
-mod message;
+pub(crate) mod message;
 
 enum UseCommand {
     KDialog(Command),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,3 +37,5 @@ pub use message::*;
 
 mod file;
 pub use file::*;
+
+mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,9 @@
+#[cfg(test)]
+
+use crate::dialog_impl::gnu::message;
+
+#[test]
+fn test_kdialog_version() {
+    let version = message::get_kdialog_version().unwrap();
+    println!("{}, {}, {}", version.0, version.1, version.2);
+}


### PR DESCRIPTION
Adds check to kdialog backend to change the formatting style depending on the version of kdialog. Fixes #41 

- [x] Parsing version string
- [ ] Find correct version to implement old formatting for