### PR TITLE
Zenity fixes for version 3.92.0

### DIFF
--- a/src/dialog_impl/gnu/file.rs
+++ b/src/dialog_impl/gnu/file.rs
@@ -241,12 +241,10 @@ fn call_zenity(mut command: Command, params: Params) -> Result<Option<Vec<u8>>> 
         command.args(&["--multiple", "--separator", "\n"]);
     }
 
-    command.arg("--filename");
-
-    match params.path {
-        Some(path) => command.arg(path),
-        None => command.arg(""),
-    };
+    if let Some(path) = params.path {
+        command.arg("--filename");
+        command.arg(path);
+    }
 
     if !params.filters.is_empty() {
         for filter in params.filters {

--- a/src/dialog_impl/gnu/message.rs
+++ b/src/dialog_impl/gnu/message.rs
@@ -138,9 +138,9 @@ fn call_zenity(mut command: Command, params: Params) -> Result<bool> {
     if params.ask {
         command.arg("--question");
         match params.typ {
-            MessageType::Info => command.arg("--icon-name=dialog-information"),
-            MessageType::Warning => command.arg("--icon-name=dialog-warning"),
-            MessageType::Error => command.arg("--icon-name=dialog-error"),
+            MessageType::Info => command.arg("--icon=dialog-information"),
+            MessageType::Warning => command.arg("--icon=dialog-warning"),
+            MessageType::Error => command.arg("--icon=dialog-error"),
         };
     } else {
         match params.typ {


### PR DESCRIPTION
When I upgraded to Fedora 38 my project had some issues due to the newer zenity version. The file dialog generated a couple errors, "The folder contents could not be displayed", "Operation was canceled / not supported" when passing --filename="", and the --question dialog wouldn't open at all due to --icon-name changing to --icon. It is probably better to query the zenity version and pass arguments tailored to the version.