### PR TITLE
Fix: Zenity confirmation silent failure

### DIFF
--- a/src/dialog_impl/gnu/mod.rs
+++ b/src/dialog_impl/gnu/mod.rs
@@ -57,12 +57,9 @@ fn get_zenity_version() -> Option<Ver> {
     get_version_output("zenity")
         .as_deref()
         .and_then(Ver::new)
-        .map(|ver| { println!("ver: {:?}", ver); ver })
-        .or_else(|| { println!("can't get zenity ver"); None })
 }
 
 fn get_version_output(program: &str) -> Option<String> {
     let output = Command::new(program).arg("--version").output().ok()?;
-    println!("version: {:?}", output);
     Some(output.stdout.as_ascii_str().ok()?.to_string())
 }

--- a/src/dialog_impl/gnu/mod.rs
+++ b/src/dialog_impl/gnu/mod.rs
@@ -57,9 +57,12 @@ fn get_zenity_version() -> Option<Ver> {
     get_version_output("zenity")
         .as_deref()
         .and_then(Ver::new)
+        .map(|ver| { println!("ver: {:?}", ver); ver })
+        .or_else(|| { println!("can't get zenity ver"); None })
 }
 
 fn get_version_output(program: &str) -> Option<String> {
     let output = Command::new(program).arg("--version").output().ok()?;
+    println!("version: {:?}", output);
     Some(output.stdout.as_ascii_str().ok()?.to_string())
 }

--- a/src/dialog_impl/gnu/version.rs
+++ b/src/dialog_impl/gnu/version.rs
@@ -6,7 +6,7 @@ pub struct Ver(SemVer);
 
 impl Ver {
     pub fn new(s: &str) -> Option<Self> {
-        let semver = SemVer::new(s)?;
+        let semver = SemVer::new(s.trim())?;
         Some(Self(semver))
     }
 }


### PR DESCRIPTION
Problem that was occurring:
- Linux OS
- Zenity present and detected properly
- Zenity version command executed successfully
- Zenity version command output **failure to parse as SemVer** due to a trailing newline character from captured stdout
- Because of failure to parse, Zenity (on my system, version 3.42.1, i.e. < 3.90.0)called with `--icon` arg, instead of `--icon-image`
- Zenity "--question" command failure due to unknown "--icon" arg passed to it
- Return code treated as a successful execution of a dialog with a "no" selection (maybe more robust error checking should be implemented in the future for similar situations)
- Ok(false) is received by calling code, instead of an Err

Solution:
- Trim whitespace off of the captured stdout from Zenity version check command
- SemVer parsing succeeds
- Zenity is called with correct arg
- Dialog appears on screen as expected

Possible solution to #54 , but not certain (best to wait for issue creator to confirm/deny this fix helped). 