### PR TITLE
Bump minimum `objc2-*` crate requirements to `0.3.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ objc2 = "0.6.3"
 # `objc2-app-kit` in particular is very large.
 # When iterating, you can temporarily add `default` to
 # the features here to make the entire crates available.
-objc2-foundation = { version = "0.3.0", default-features = false, features = [
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
     "std",
     "objc2-core-foundation",
     "NSArray",
@@ -44,7 +44,7 @@ objc2-foundation = { version = "0.3.0", default-features = false, features = [
     "NSThread",
     "NSURL",
 ] }
-objc2-app-kit = { version = "0.3.0", default-features = false, features = [
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
     "std",
     "block2",
     "objc2-core-foundation",
@@ -74,11 +74,11 @@ objc2-app-kit = { version = "0.3.0", default-features = false, features = [
     "NSView",
     "NSWindow",
 ] }
-objc2-core-foundation = { version = "0.3.0", default-features = false, features = [
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
     "std",
     "CFCGTypes",
 ] }
-objc2-core-graphics = { version = "0.3.0", default-features = false, features = [
+objc2-core-graphics = { version = "0.3.2", default-features = false, features = [
     "std",
     "CGContext",
     "CGColor",


### PR DESCRIPTION
When the edition-2024 upgrade was pushed a bunch of `unsafe {}` wrappers around `objc2` function calls were removed in 473d78059c07deaa21d414994a164bf04617772b. This had little to do with Rust Edition 2024, and everything with `objc2` automatically marking more functions in the latest release per https://github.com/madsmtm/objc2/pull/783.

To match, `native-dialog` should require these versions at a minimum or downstream crates with older dependencies in their lockfile will fail to compile if they still have `objc2-*` crates pinned on `<0.3.2`.

CC @madsmtm 