### PR TITLE
error: Print error strings in `thiserror` formatting implementation

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,9 +15,9 @@ pub enum Error {
     #[error("cannot find implementation (kdialog/zenity/yad)")]
     MissingDep,
 
-    #[error("subprocess killed by signal")]
+    #[error("subprocess killed by signal: {0:?}")]
     Killed(OsString),
 
-    #[error("other errors reported by implementation")]
+    #[error("other errors reported by implementation: {0}")]
     Other(String),
 }


### PR DESCRIPTION
For `#[source]` errors, implied by `#[from]` above, it is expected to *not* include the source error in the format string as surrounding implementations may manually walk the `.source()` chain and invoke the `Display` implementation of each error to pretty-print a nice stack, where errors would show up many times if the nested error was part of the `Display` print.

However the `Killed()` and `Other()` variants contain plain strings that are not or cannot even be returned out of `.source()` (they don't implement `trait Error`), thus they are completely missing in any error-printing unless the caller manually maps this crates' `Error` type.  Include the nested field in the format string so that it's always visible in downstream crates.

Note that the aforementioned `.source()` walking is implemented by `anyhow::Error` on its alt-`Display` and `Debug` implementations, but is suspiciously missing on all `thiserror` abstractions despite both crates being from the same author; the alt-`Display` implementation could be provided by `thiserror` but the `Debug` implementation is still/already a separate `#[derive]`.  This makes `.unwrap()` and even returning this error directly out of `fn main()` (both call into `Debug` without alt-format) useless as no `.source()` information is included. (https://github.com/dtolnay/thiserror/issues/98)

Hence all consumers of this crate are expected to re-wrap the returned `Error` object anyway to make sure they even get to see the nested errors (especially `std::io::Error`) other than just "system error or I/O failure".
