### PR TITLE
win: Include `hresult` when printing "`Other`" error

### DIFF
--- a/src/dialog/win/file.rs
+++ b/src/dialog/win/file.rs
@@ -227,10 +227,14 @@ fn convert_result<T>(result: std::result::Result<T, DialogError>) -> Result<Opti
         Ok(t) => Ok(Some(t)),
         Err(e) => match e {
             DialogError::UserCancelled => Ok(None),
-            DialogError::HResultFailed { error_method, .. } => Err(Error::Other(error_method)),
-            DialogError::UnsupportedFilepath => {
-                Err(Error::Other("Unsupported filepath".to_string()))
-            }
+            DialogError::HResultFailed {
+                error_method,
+                hresult,
+            } => Err(Error::WindowsMethod(
+                error_method,
+                std::io::Error::from_raw_os_error(hresult),
+            )),
+            DialogError::UnsupportedFilepath => Err(Error::WindowsUnsupportedFilepath),
         },
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,6 +18,9 @@ pub enum Error {
     #[error("subprocess killed by signal: {0:?}")]
     Killed(OsString),
 
-    #[error("other errors reported by implementation: {0}")]
-    Other(String),
+    #[error("Windows method `{0}` failed")]
+    WindowsMethod(String, #[source] std::io::Error),
+
+    #[error("The filepath of the selected folder or item is not supported")]
+    WindowsUnsupportedFilepath,
 }


### PR DESCRIPTION
Depends on #75

The `error_method` field, as its name "somewhat" describes, is the **name** of the COM method that failed with a particular error code. The actual error code is in the `hresult` field.

To make this error more easily readable to users, wrap it in `std::io::Error` using `from_raw_os_error()` which takes `HRESULT` integers.

Note that like the other `#[from]` (which implies `#[source]`) errors above in this crate these nested errors are *not* included in the `Display` formatter generated by `thiserror`; callers are expected to `Debug`-print the returned `Error` or wrap it in a more useful type like `anyhow::Error` which nicely `Debug`-prints all `.source()` errors as a stack (see https://github.com/dtolnay/thiserror/issues/98 to hopefully have the same behaviour in `thiserror` some day).
